### PR TITLE
remove srcset when replacing

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -58,6 +58,7 @@ function replaceImage(source) {
     return;
   }
   imageEl.src = source;
+  imageEl.removeAttribute("srcset");
 }
 
 // checks wheather the URL is valid


### PR DESCRIPTION
On modern websites, images often use the srcset attribute. If they are loaded using this, it may not work to just change the src attribute, because the browser loaded one of the srcset images. By removing the srcset on replace, the browser is forced to take the image from src. Now it works again.